### PR TITLE
[feat] 컨트롤과 제어변수 연결 및 smtp 서버 주소 자동 설정

### DIFF
--- a/MailyChristmas/MailyChristmasDlg.h
+++ b/MailyChristmas/MailyChristmasDlg.h
@@ -22,6 +22,10 @@ public:
 
 
 // 구현입니다.
+private:
+	static void	_parseEmailAddr(LPCTSTR lpszSrc, CString& name, CString& address);
+	static void _splitAddr(LPCTSTR lpszSrc, CStringArray& values);
+	void _changeSettingforWellKnownServer();
 protected:
 	HICON m_hIcon;
 
@@ -31,4 +35,14 @@ protected:
 	afx_msg void OnPaint();
 	afx_msg HCURSOR OnQueryDragIcon();
 	DECLARE_MESSAGE_MAP()
+public:
+	afx_msg void OnBnClickedButton1();
+	afx_msg void OnChangeEditFrom();
+	CString m_from;
+	CString m_server;
+	CString m_user;
+	afx_msg void OnChangeEditServer();
+	afx_msg void OnClickedButtonAdd();
+	afx_msg void OnBnClickedOk();
+	CString m_to;
 };


### PR DESCRIPTION
## Related Issue

- Issue #3

## Changes

- 컨트롤과 제어변수 연결
 - 입력한 발신 메일 주소에 따라서 smtp 서버 주소를 자동 설정
 - 전송 버튼 클릭 시 성공 메시지 박스 생성 / 발신인, 수신인 미입력 시 에러 메시지 박스 생성

## Screenshot
